### PR TITLE
Add JWT authentication

### DIFF
--- a/pkg/auth/oauth2.go
+++ b/pkg/auth/oauth2.go
@@ -54,7 +54,7 @@ func createStateString(service string) string {
 
 	data := make([]byte, 30) // 30 characters should be a good random string
 	if _, err := io.ReadFull(rand.Reader, data); err != nil {
-		return ""
+		return "" // TODO: return an error here, log it and return an error for the end user
 	}
 
 	// add the service type to the front and the userID in the back

--- a/pkg/service/dal.go
+++ b/pkg/service/dal.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	_ "github.com/lib/pq"
+	"github.com/msgurgel/marathon/pkg/environment"
+)
+
+func InitializeDBConn(config *environment.MarathonConfig) (*sql.DB, error) {
+	connectionString := fmt.Sprintf(
+		"host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
+		config.Database.Host, config.Database.Port, config.Database.User, config.Database.Password, config.Database.DatabaseName,
+	)
+
+	db, err := sql.Open("postgres", connectionString)
+	if err != nil {
+		return nil, err
+	}
+
+	// Test connection
+	err = db.PingContext(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	return db, nil
+}
+
+func InsertSecretInExistingClient(db *sql.DB, clientId int, secret []byte) (int64, error) {
+	// TODO: Use ExecContext instead
+	result, err := db.Exec(
+		`UPDATE marathon.public.client
+				SET secret = $1
+				WHERE id = $2`,
+		secret,
+		clientId,
+	)
+
+	if err != nil {
+		return 0, err
+	}
+
+	rows, _ := result.RowsAffected()
+	return rows, nil
+}
+
+func GetClientSecret(db *sql.DB, fromClientId int) ([]byte, error) {
+	// TODO: Use QueryRowContext instead
+	var secret []byte
+	err := db.QueryRow("SELECT secret FROM client WHERE id = $1", fromClientId).Scan(&secret)
+	if err != nil {
+		return nil, err
+	}
+
+	return secret, nil
+}

--- a/pkg/service/token.go
+++ b/pkg/service/token.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/sirupsen/logrus"
+)
+
+type marathonClaims struct {
+	ClientId int `json:"client_id"`
+	jwt.StandardClaims
+}
+
+func generateJWT(clientId int, secret []byte) (string, error) {
+	token := jwt.New(jwt.SigningMethodHS256)
+
+	claims := token.Claims.(jwt.MapClaims)
+	claims["client_id"] = clientId
+	// claims["exp"] = time.Now().Add(time.Hour * 24).Unix() TODO: Add exp back
+
+	// Sign the token with the given secret
+	tokenString, _ := token.SignedString(secret)
+	return tokenString, nil
+}
+
+func validateJWT(db *sql.DB, tokenString string) (bool, error) {
+	token, err := jwt.ParseWithClaims(tokenString, &marathonClaims{}, func(token *jwt.Token) (interface{}, error) {
+		if claims, ok := token.Claims.(*marathonClaims); ok {
+			return GetClientSecret(db, claims.ClientId)
+		} else {
+			return nil, errors.New("unable to parse JWT claims")
+		}
+	})
+
+	if err != nil {
+		return false, err
+	}
+
+	return token.Valid, nil
+}
+
+func jwtMiddleware(db *sql.DB, log *logrus.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var token string
+
+		// Get token from the Authorization header
+		// format: Authorization: Bearer
+		tokens, ok := r.Header["Authorization"]
+		if ok && len(tokens) >= 1 {
+			token = tokens[0]
+			token = strings.TrimPrefix(token, "Bearer ")
+		}
+
+		valid, err := validateJWT(db, token)
+		if valid {
+			next.ServeHTTP(w, r)
+		} else {
+			log.WithFields(logrus.Fields{
+				"err": err,
+			}).Error("JWT token was invalid")
+
+			respondWithError(w, http.StatusUnauthorized, "invalid JWT token")
+		}
+	})
+}


### PR DESCRIPTION
Closes #36 

### JWT Creation
JWT are now generated through the following flow:
1. A request is made to `/get-token`, passing an `id` query variable (this will have to be changed to something more secure. See #39)
2. A 512-bit random secret is generated and it is stored in the `client` table of the `marathon` db, associated to the given `id`.
3. A JWT is created using the generated secret and the `id` is stored in the token as a `client_id` claim.
4. The JWT is send to original requester.

### JWT Verification
JWT are now verified properly in endpoints flagged as `Secure`. Their flow is as follows:
1. JWT middleware is called when a request is made to a `Secure` endpoint
2. Claims are extracted from received JWT. Using the extracted `client_id` claim, request associated `secret` from the database.
3. Using the `secret` from the database, verify the JWT signature.
