### PR TITLE
Add end-to-end integration test framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .env
 .DS_Store
 runtime.log
+log/
+setup-db-env-vars.sh

--- a/integration-test/end-2-end/end-2-end-test.sh
+++ b/integration-test/end-2-end/end-2-end-test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# ======= BEFORE RUNNING THIS SCRIPT =======
+# 1. Make sure to run 'bundle install' on the both ruby app directories (integration-test/end-2-end/sandwich & integration-test/end-2-end/sandwich/server)
+# 2. Set your Postgres env vars in setup-db-env-var.sh.example file and remove .example from the file name
+# 3. Run this script from marathon's home directory ($GOPATH/src/github.com/msgurgel/marathon) using the following command:
+#   ./integration-test/end-2-end/end-2-end-test.sh
+
+# Get database environment values
+source ./integration-test/end-2-end/setup-db-env-vars.sh
+
+# Create log directory
+mkdir -p log
+
+# Run setup database script
+psql -a -d $PGDATABASE -f integration-test/end-2-end/sql/clear-db.sql > log/db_script.log
+psql -a -d $PGDATABASE -f integration-test/end-2-end/sql/setup-db.sql > log/db_script.log
+
+# Build and run Marathon
+go build "$GOPATH"/src/github.com/msgurgel/marathon/cmd/marathon
+./marathon &
+MARATHON_PID=$!
+
+sleep 1 # Give the server time to start
+
+# Generate JWT for authentication
+curl -s "http://localhost:8080/get-token?id=1" > token.txt
+
+# Run mock third-party server
+rackup integration-test/end-2-end/sandwich/server/config.ru > log/server.log 2>&1 &
+SERVER_PID=$!
+
+sleep 1 # Give the server time to start
+
+# Run tests!
+ruby integration-test/end-2-end/sandwich/sandwich_test.rb
+
+# Exit cleanly
+kill -2 $MARATHON_PID
+kill -2 $SERVER_PID
+
+rm ./marathon
+rm ./token.txt
+
+# Clear database
+psql -a -d $PGDATABASE -f integration-test/end-2-end/sql/clear-db.sql > log/db_script.log

--- a/integration-test/end-2-end/sandwich/Gemfile
+++ b/integration-test/end-2-end/sandwich/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'minitest'
+gem 'minitest-reporters'
+gem 'httparty'

--- a/integration-test/end-2-end/sandwich/Gemfile.lock
+++ b/integration-test/end-2-end/sandwich/Gemfile.lock
@@ -1,0 +1,30 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ansi (1.5.0)
+    builder (3.2.4)
+    httparty (0.18.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.1009)
+    minitest (5.14.0)
+    minitest-reporters (1.4.2)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
+    multi_xml (0.6.0)
+    ruby-progressbar (1.10.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  httparty
+  minitest
+  minitest-reporters
+
+BUNDLED WITH
+   2.1.4

--- a/integration-test/end-2-end/sandwich/sandwich_test.rb
+++ b/integration-test/end-2-end/sandwich/sandwich_test.rb
@@ -1,0 +1,29 @@
+require "minitest/autorun"
+require "minitest/reporters"
+Minitest::Reporters.use! Minitest::Reporters::ProgressReporter.new
+
+require 'net/http'
+require 'json'
+require 'httparty'
+
+class SandwichTest < Minitest::Test
+    def setup
+        token_file = File.open('token.txt')
+        @jwt = token_file.read
+        token_file.close
+    end
+
+    def test_get_steps_fitbit
+        response = HTTParty.get('http://localhost:8080/user/1/steps?date=2020-02-13', {
+            headers: {
+                "User-Agent" => "Sandwich",
+                "Authorization" => "Bearer #{@jwt}"
+            }
+        })
+        parsed = JSON.parse(response.body)
+
+        assert_equal parsed["id"], 1
+        assert_equal parsed["steps"][0]["platform"], 'fitbit'
+        assert_equal parsed["steps"][0]["value"], 2020
+    end
+end

--- a/integration-test/end-2-end/sandwich/server/Gemfile
+++ b/integration-test/end-2-end/sandwich/server/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'grape'
+gem 'rack'

--- a/integration-test/end-2-end/sandwich/server/Gemfile.lock
+++ b/integration-test/end-2-end/sandwich/server/Gemfile.lock
@@ -1,0 +1,65 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.0.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
+    builder (3.2.4)
+    concurrent-ruby (1.1.6)
+    dry-configurable (0.11.2)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.4, >= 0.4.7)
+      dry-equalizer (~> 0.2)
+    dry-container (0.7.2)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 0.1, >= 0.1.3)
+    dry-core (0.4.9)
+      concurrent-ruby (~> 1.0)
+    dry-equalizer (0.3.0)
+    dry-inflector (0.2.0)
+    dry-logic (1.0.6)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 0.2)
+      dry-equalizer (~> 0.2)
+    dry-types (1.3.1)
+      concurrent-ruby (~> 1.0)
+      dry-container (~> 0.3)
+      dry-core (~> 0.4, >= 0.4.4)
+      dry-equalizer (~> 0.3)
+      dry-inflector (~> 0.1, >= 0.1.2)
+      dry-logic (~> 1.0, >= 1.0.2)
+    grape (1.3.0)
+      activesupport
+      builder
+      dry-types (>= 1.1)
+      mustermann-grape (~> 1.0.0)
+      rack (>= 1.3.0)
+      rack-accept
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
+    minitest (5.14.0)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    mustermann-grape (1.0.1)
+      mustermann (>= 1.0.0)
+    rack (2.2.2)
+    rack-accept (0.4.5)
+      rack (>= 0.4)
+    ruby2_keywords (0.0.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.6)
+      thread_safe (~> 0.1)
+    zeitwerk (2.2.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  grape
+  rack
+
+BUNDLED WITH
+   2.1.4

--- a/integration-test/end-2-end/sandwich/server/api.rb
+++ b/integration-test/end-2-end/sandwich/server/api.rb
@@ -1,0 +1,28 @@
+require 'grape'
+
+module TestServer
+    class API < Grape::API
+        format :json
+
+        # Mocks Fitbit endpoints
+        resource :fitbit do
+            resource :user do
+                route_param :user_id do
+                    resource :activities do
+                        resource :date do
+                            get :"2020-02-13.json" do
+                                {
+                                    summary: {
+                                        caloriesOut: 1010,
+                                        steps: 2020
+                                    }
+                                }
+                            end
+                        end
+                    end
+                end
+           end
+       end
+
+    end
+end

--- a/integration-test/end-2-end/sandwich/server/config.ru
+++ b/integration-test/end-2-end/sandwich/server/config.ru
@@ -1,0 +1,5 @@
+# config.ru
+require 'rack'
+require_relative 'api'
+
+run TestServer::API # Mounts on top of Rack.

--- a/integration-test/end-2-end/setup-db-env-vars.sh.example
+++ b/integration-test/end-2-end/setup-db-env-vars.sh.example
@@ -1,0 +1,6 @@
+# PostgreSQL Vars
+PGHOST=localhost
+PGPORT=5432
+PGUSER=
+PGPASSWORD=
+PGDATABASE=marathon

--- a/integration-test/end-2-end/sql/clear-db.sql
+++ b/integration-test/end-2-end/sql/clear-db.sql
@@ -1,0 +1,13 @@
+-- Restart DB
+DELETE FROM credentials;
+DELETE FROM platform;
+DELETE FROM userbase;
+DELETE FROM client;
+DELETE FROM "user";
+
+ALTER SEQUENCE credentials_id_seq RESTART WITH 1;
+ALTER SEQUENCE platform_id_seq RESTART WITH 1;
+ALTER SEQUENCE userbase_id_seq RESTART WITH 1;
+ALTER SEQUENCE client_id_seq RESTART WITH 1;
+ALTER SEQUENCE user_id_seq RESTART WITH 1;
+

--- a/integration-test/end-2-end/sql/setup-db.sql
+++ b/integration-test/end-2-end/sql/setup-db.sql
@@ -1,0 +1,7 @@
+-- Insert initial setup values
+INSERT INTO "user" DEFAULT VALUES; -- Creates User 1
+INSERT INTO platform (name, domain) VALUES ('fitbit', 'http://localhost:9292/fitbit'); -- Creates mock Fitbit
+INSERT INTO credentials (user_id, platform_id, upid, connection_string) VALUES (1, 1, 'A1B2C3', 'oauth2;ACC3$$T0K3N;R3FR3$HT0K3N');
+INSERT INTO client (name) VALUES ('Sandwich'); -- Creates our test app client
+INSERT INTO userbase (user_id, client_id) VALUES (1, 1);
+


### PR DESCRIPTION
Adds a framework for writing future end-to-end tests to marathon.
In a nutshell, this is what it does:
1. Sets up an existing local database with test data
2. Builds and runs the Marathon server
3. Runs a Ruby app that will sandwich Marathon, acting as the caller of APIs *and* the receiver of the third-party calls
4. Execute all the tests defined in the Ruby app and print the results to the console
5. Stop the REST API server, stop Marathon and clear the database 