### PR TITLE
Add a check where new users are checked against clients userbases

### DIFF
--- a/pkg/dal/dal.go
+++ b/pkg/dal/dal.go
@@ -95,23 +95,22 @@ func GetUserByPlatformID(db *sql.DB, platformID string, platformName string) (in
 	return userID, nil
 }
 
-func AddUserToClientUserBase(db *sql.DB, userID int, clientID int) error {
-	_, err := db.Exec(`INSERT into userbase(user_id, client_id) VALUES($1,$2)`, userID, clientID)
+func AddUserToUserbase(db *sql.DB, userID int, clientID int) error {
+	queryString := fmt.Sprintf("INSERT INTO userbase (user_id, client_id) VALUES (%d, %d)", userID, clientID)
+
+	_, err := db.Exec(queryString)
 
 	if err != nil {
 		return err
 	}
 
 	return nil
-
 }
 
-func GetUserInUserBase(db *sql.DB, userID int, clientID int) (int, error) {
-
+func GetUserInUserbase(db *sql.DB, userID int, clientID int) (int, error) {
 	// check if this user exists already in the userbase
 	queryString := fmt.Sprintf(
-		"SELECT user_id FROM userBase "+
-			"WHERE user_id = '%d' AND client_id = '%d'",
+		"SELECT user_id FROM userbase WHERE user_id = %d AND client_id = %d",
 		userID,
 		clientID,
 	)
@@ -297,7 +296,7 @@ func GetPlatformDomains(db *sql.DB) (map[string]string, error) {
 // CheckClientName takes in a client name, and returns the userId of the client,
 // or 0 if no client is using that name
 func CheckClientName(db *sql.DB, name string) (int, error) {
-	searchQuery := fmt.Sprintf("SELECT id FROM client WHERE name='%s'", name)
+	searchQuery := fmt.Sprintf("SELECT id FROM client WHERE name = '%s'", name)
 
 	var userId int
 	// TODO: Use QueryRowContext instead
@@ -326,7 +325,7 @@ func CreateNewClient(db *sql.DB, name string, password string) error {
 		return err
 	}
 
-	insertQuery := fmt.Sprintf("INSERT INTO client (name, password) VALUES('%s','%s')", name, hash)
+	insertQuery := fmt.Sprintf("INSERT INTO client (name, password) VALUES ('%s','%s')", name, hash)
 
 	// TODO: Use ExecContext instead
 	_, err = db.Exec(insertQuery)
@@ -341,7 +340,7 @@ func CreateNewClient(db *sql.DB, name string, password string) error {
 
 func SignInClient(db *sql.DB, name string, enteredPassword string) (int, error) {
 
-	searchQuery := fmt.Sprintf("SELECT password,id FROM client WHERE name='%s'", name)
+	searchQuery := fmt.Sprintf("SELECT password, id FROM client WHERE name = '%s'", name)
 
 	var passwordResult string
 	var userId int

--- a/pkg/dal/dal_test.go
+++ b/pkg/dal/dal_test.go
@@ -37,7 +37,7 @@ func TestInsertSecretInExistingClient_ShouldInsertSecret(t *testing.T) {
 	clientID := 1
 
 	// Mock expected SQL queries
-	Mock.ExpectExec(`^UPDATE client`).
+	Mock.ExpectExec(`^UPDATE client SET secret`).
 		WithArgs(secret, clientID).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -69,7 +69,7 @@ func TestGetClientSecret_ShouldGetSecret(t *testing.T) {
 	rows := sqlmock.NewRows(cols).AddRow(secret)
 
 	// Mock expected SQL queries
-	expectedSQL := fmt.Sprintf("^SELECT secret FROM client WHERE id = %d*", clientID)
+	expectedSQL := fmt.Sprintf("^SELECT secret FROM client WHERE id = %d$", clientID)
 	Mock.ExpectQuery(expectedSQL).WillReturnRows(rows)
 
 	// Call the func that we are testing
@@ -93,7 +93,7 @@ func TestGetUserTokens_ShouldGetTokens(t *testing.T) {
 	userID := 1
 	platformID := 1
 
-	platformIDQuery := fmt.Sprintf("^SELECT id FROM platform WHERE name = '%s'*", platformName)
+	platformIDQuery := fmt.Sprintf("^SELECT id FROM platform WHERE name = '%s'$", platformName)
 	Mock.ExpectQuery(platformIDQuery).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(platformID))
 
 	cols := []string{
@@ -101,13 +101,18 @@ func TestGetUserTokens_ShouldGetTokens(t *testing.T) {
 	}
 	rows := sqlmock.NewRows(cols).AddRow("oauth2;AC3$$T0K3N;R3FR3$HT0K3N")
 
-	expectedSQL := fmt.Sprintf("^SELECT connection_string FROM credentials WHERE user_id = %d AND platform_id = %d*", userID, platformID)
+	expectedSQL := fmt.Sprintf("^SELECT connection_string FROM credentials WHERE user_id = %d AND platform_id = %d$", userID, platformID)
 	Mock.ExpectQuery(expectedSQL).WillReturnRows(rows)
 
 	accessTkn, refreshTkn, err := GetUserTokens(DB, userID, platformName)
 	if err != nil {
 		t.Errorf("failed to get user tokens: %s", err.Error())
 		return
+	}
+
+	// We make sure that all expectations were met
+	if err := Mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
 
 	assert.Equal(t, "AC3$$T0K3N", accessTkn)
@@ -127,13 +132,18 @@ func TestGetPlatformNames(t *testing.T) {
 		rows = rows.AddRow(platName)
 	}
 
-	expectedSQL := fmt.Sprintf(`^SELECT name FROM platform p JOIN (.+) WHERE user_id = %d*`, userID)
+	expectedSQL := fmt.Sprintf(`^SELECT name FROM platform p JOIN (.+) WHERE user_id = %d$`, userID)
 	Mock.ExpectQuery(expectedSQL).WillReturnRows(rows)
 
 	platformStr, err := GetPlatformNames(DB, userID)
 	if err != nil {
 		t.Errorf("failed to get platforms: %s", err.Error())
 		return
+	}
+
+	// We make sure that all expectations were met
+	if err := Mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
 
 	assert.Equal(t, expectedPlatforms, platformStr)
@@ -153,7 +163,7 @@ func TestGetUserByPlatformID(t *testing.T) {
 	expectedSQL := fmt.Sprintf(
 		"^SELECT user_id FROM credentials [a-z] "+
 			"JOIN platform [a-z]+ ON (.+) "+
-			"WHERE [a-z]+.name = '%s' AND [a-z]+.upid = '%s'*",
+			"WHERE [a-z]+.name = '%s' AND [a-z]+.upid = '%s'$",
 		platName,
 		platID,
 	)
@@ -163,6 +173,11 @@ func TestGetUserByPlatformID(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to get user: %s", err.Error())
 		return
+	}
+
+	// We make sure that all expectations were met
+	if err := Mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
 
 	assert.Equal(t, expectedUserID, userID)
@@ -180,20 +195,17 @@ func TestInsertUserCredentials_ShouldInsertCredentials(t *testing.T) {
 	// Mock expected DB calls in order
 	Mock.ExpectBegin()
 	Mock.ExpectQuery(
-		`^INSERT INTO "user"`).
+		`^INSERT INTO "user" DEFAULT VALUES RETURNING id$`).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(userID))
 
-	expectedPlatIDSQL := fmt.Sprintf("^SELECT id FROM platform WHERE name = '%s'", platName)
+	expectedPlatIDSQL := fmt.Sprintf(`^SELECT id FROM platform WHERE name = '%s'$`, platName)
 	Mock.ExpectQuery(expectedPlatIDSQL).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(platID))
 
-	expectedCredentialsSQL := fmt.Sprintf(
-		"^INSERT INTO credentials (.+) VALUES (%d, %d, '%s', '%s')*",
-		clientID, platID, UPID, connStr,
-	)
+	expectedCredentialsSQL := `^INSERT INTO credentials (.+) VALUES \(\d+, \d+, (.+), (.+)\)$`
 	Mock.ExpectExec(expectedCredentialsSQL).WillReturnResult(sqlmock.NewResult(1, 1))
 
 	expectedUserbaseSQL := fmt.Sprintf(
-		`^INSERT INTO userbase (.+) VALUES \(%d, %d\)*`, // Need to escape the parenthesis or else Regex will think it's a capture group
+		`^INSERT INTO userbase (.+) VALUES \(%d, %d\)$`, // Need to escape the parenthesis or else Regex will think it's a capture group
 		userID, clientID,
 	)
 	Mock.ExpectExec(expectedUserbaseSQL).WillReturnResult(sqlmock.NewResult(1, 1))
@@ -226,11 +238,11 @@ func TestGetUserConnection_ShouldGetConnection(t *testing.T) {
 	platName := "fitbit"
 	connStr := "oauth2;AC3$$T0K3N;R3FR3$HT0K3N"
 
-	platformIDQuery := fmt.Sprintf("^SELECT id FROM platform WHERE name = '%s'*", platName)
+	platformIDQuery := fmt.Sprintf("^SELECT id FROM platform WHERE name = '%s'$", platName)
 	Mock.ExpectQuery(platformIDQuery).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(platID))
 
 	connStrQuery := fmt.Sprintf(
-		"^SELECT connection_string FROM credentials WHERE user_id = %d AND platform_id = %d*",
+		"^SELECT connection_string FROM credentials WHERE user_id = %d AND platform_id = %d$",
 		userID, platID,
 	)
 	Mock.ExpectQuery(connStrQuery).WillReturnRows(sqlmock.NewRows([]string{"connection_string"}).AddRow(connStr))
@@ -271,7 +283,7 @@ func TestGetPlatformDomains_ShouldGetDomains(t *testing.T) {
 		AddRow("google-fit", "api.google.com").
 		AddRow("map-my-tracks", "api.mpt.ca")
 
-	Mock.ExpectQuery("^SELECT name, domain FROM platform*").WillReturnRows(rows)
+	Mock.ExpectQuery("^SELECT name, domain FROM platform$").WillReturnRows(rows)
 
 	actualDomains, err := GetPlatformDomains(DB)
 	if err != nil {
@@ -297,11 +309,11 @@ func TestSignUp_ShouldInsertNewClient(t *testing.T) {
 	clientName := "New_Client"
 	clientPassword := "Client_Password"
 
-	Mock.ExpectExec(`INSERT INTO client`).WillReturnResult(sqlmock.NewResult(1, 1))
+	Mock.ExpectExec(`^INSERT INTO client (.+) VALUES (.+)$`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	// call the function we are testing
 	err := CreateNewClient(DB, clientName, clientPassword)
-
 	if err != nil {
 		t.Errorf("error was not expected when inserting a client: %s", err)
 	}
@@ -310,7 +322,6 @@ func TestSignUp_ShouldInsertNewClient(t *testing.T) {
 	if err := Mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
-
 }
 
 func TestSignIn_ShouldSignInExistingClient(t *testing.T) {
@@ -325,20 +336,21 @@ func TestSignIn_ShouldSignInExistingClient(t *testing.T) {
 		"password",
 		"id",
 	}
-	rows := sqlmock.NewRows(cols).
-		AddRow(hashedPassword, clientID)
-
-	Mock.ExpectQuery(fmt.Sprintf("SELECT password,id FROM client WHERE name='%s'", clientName)).WillReturnRows(rows)
+	rows := sqlmock.NewRows(cols).AddRow(hashedPassword, clientID)
+	Mock.ExpectQuery(fmt.Sprintf("^SELECT password, id FROM client WHERE name = '%s'$", clientName)).WillReturnRows(rows)
 
 	// call the function we are testing
 	returnedId, err := SignInClient(DB, clientName, clientPassword)
-
 	if err != nil {
 		t.Errorf("error was not expected when signing in a client: %s", err)
 	}
 
-	assert.Equal(t, clientID, returnedId)
+	// We make sure that all expectations were met
+	if err := Mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
 
+	assert.Equal(t, clientID, returnedId)
 }
 
 func TestCheckClientName_ShouldReturnUserId(t *testing.T) {
@@ -349,44 +361,46 @@ func TestCheckClientName_ShouldReturnUserId(t *testing.T) {
 	cols := []string{
 		"id",
 	}
-	rows := sqlmock.NewRows(cols).
-		AddRow(clientID)
+	rows := sqlmock.NewRows(cols).AddRow(clientID)
 
-	Mock.ExpectQuery(fmt.Sprintf("SELECT id FROM client WHERE name='%s'", clientName)).WillReturnRows(rows)
+	Mock.ExpectQuery(fmt.Sprintf("^SELECT id FROM client WHERE name = '%s'$", clientName)).WillReturnRows(rows)
 
 	// call the function we are testing
 	returnedId, err := CheckClientName(DB, clientName)
-
 	if err != nil {
 		t.Errorf("error was not expected when searching for a client: %s", err)
 	}
 
-	assert.Equal(t, clientID, returnedId)
+	// We make sure that all expectations were met
+	if err := Mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
 
+	assert.Equal(t, clientID, returnedId)
 }
 
-func TestAddClientToUserBase_ShouldNotReturnError(t *testing.T) {
-
+func TestAddUserToUserbase_ShouldNotReturnError(t *testing.T) {
 	clientID := 1
 	userID := 1
 
-	Mock.ExpectExec(`^INSERT into userbase`).
-		WithArgs(userID, clientID).
+	Mock.ExpectExec(`^INSERT INTO userbase (.+) VALUES \(\d+, \d+\)$`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	// call the function we are testing
-	err := AddUserToClientUserBase(DB, userID, clientID)
-
+	err := AddUserToUserbase(DB, userID, clientID)
 	if err != nil {
-		t.Errorf("error was not expected when adding a userId to a client userbase: %s", err)
+		t.Errorf("error was not expected when adding a userID to a client userbase: %s", err)
+	}
+
+	// We make sure that all expectations were met
+	if err := Mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
 
 	assert.Equal(t, err, nil)
-
 }
 
-func TestGetUserInUserBase_ShouldReturnUserId(t *testing.T) {
-
+func TestGetUserInUserbase_ShouldReturnUserID(t *testing.T) {
 	clientID := 1
 	userID := 1
 
@@ -396,16 +410,16 @@ func TestGetUserInUserBase_ShouldReturnUserId(t *testing.T) {
 	}
 	rows := sqlmock.NewRows(cols).AddRow(userID)
 
-	expectedSQL := fmt.Sprintf("^SELECT user_id FROM userBase WHERE user_id = '%d' AND client_id = '%d'", userID, clientID)
+	expectedSQL := fmt.Sprintf("^SELECT user_id FROM userbase WHERE user_id = %d AND client_id = %d$", userID, clientID)
 	Mock.ExpectQuery(expectedSQL).WillReturnRows(rows)
 
 	// call the function we are testing
-	userIdActual, err := GetUserInUserBase(DB, userID, clientID)
+	userIDActual, err := GetUserInUserbase(DB, userID, clientID)
 
 	if err != nil {
-		t.Errorf("error was not expected when adding a userId to a client userbase: %s", err)
+		t.Errorf("error was not expected when adding a userID to a client userbase: %s", err)
 	}
 
-	assert.Equal(t, userID, userIdActual)
+	assert.Equal(t, userID, userIDActual)
 
 }

--- a/pkg/service/api.go
+++ b/pkg/service/api.go
@@ -476,7 +476,7 @@ func createUser(Oauth2Params *auth.OAuth2Result, db *sql.DB, log *logrus.Logger)
 			// However, the user may not exist in the clients userbase
 			// check if they do
 
-			userID, err := dal.GetUserInUserBase(db, userID, Oauth2Params.ClientID)
+			userID, err := dal.GetUserInUserbase(db, userID, Oauth2Params.ClientID)
 
 			if err != nil {
 				return 0, err
@@ -484,7 +484,7 @@ func createUser(Oauth2Params *auth.OAuth2Result, db *sql.DB, log *logrus.Logger)
 
 			if userID == 0 {
 				// the user exists, but is not in the clients userbase. Add it.
-				err := dal.AddUserToClientUserBase(db, userID, Oauth2Params.ClientID)
+				err := dal.AddUserToUserbase(db, userID, Oauth2Params.ClientID)
 				if err != nil {
 					return 0, err
 				}


### PR DESCRIPTION
Now, when a new user is being created:

- First checks if Marathon already has that user in the platform specified
- If it does, checks if the client has that user in their user base. If not, add it, then return the userId

Fixes #59 