### PR TITLE
Add user info to signup request

### DIFF
--- a/pkg/dal/dal.go
+++ b/pkg/dal/dal.go
@@ -315,26 +315,27 @@ func CheckClientName(db *sql.DB, name string) (int, error) {
 
 }
 
-func CreateNewClient(db *sql.DB, name string, password string) error {
+func CreateNewClient(db *sql.DB, name string, password string) (int, error) {
 
 	// before we insert the password in the database, we must hash it
 	// bcrypt salts this for us, so we don't have to worry about it
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 
 	if err != nil {
-		return err
+		return 0, err
 	}
 
-	insertQuery := fmt.Sprintf("INSERT INTO client (name, password) VALUES ('%s','%s')", name, hash)
+	var clientID int
+	insertQuery := fmt.Sprintf("INSERT INTO client (name, password) VALUES ('%s','%s') RETURNING id", name, hash)
 
 	// TODO: Use ExecContext instead
-	_, err = db.Exec(insertQuery)
+	err = db.QueryRow(insertQuery).Scan(&clientID)
 
 	if err != nil {
-		return err
+		return 0, err
 	}
 
-	return nil
+	return clientID, nil
 
 }
 

--- a/pkg/dal/dal_test.go
+++ b/pkg/dal/dal_test.go
@@ -309,11 +309,16 @@ func TestSignUp_ShouldInsertNewClient(t *testing.T) {
 	clientName := "New_Client"
 	clientPassword := "Client_Password"
 
-	Mock.ExpectExec(`^INSERT INTO client (.+) VALUES (.+)$`).
-		WillReturnResult(sqlmock.NewResult(1, 1))
+	// Mock SQL rows
+	cols := []string{
+		"id",
+	}
+	rows := sqlmock.NewRows(cols).AddRow(1)
+
+	Mock.ExpectQuery(`INSERT INTO client (.+) VALUES (.+)$`).WillReturnRows(rows)
 
 	// call the function we are testing
-	err := CreateNewClient(DB, clientName, clientPassword)
+	clientID, err := CreateNewClient(DB, clientName, clientPassword)
 	if err != nil {
 		t.Errorf("error was not expected when inserting a client: %s", err)
 	}
@@ -322,6 +327,8 @@ func TestSignUp_ShouldInsertNewClient(t *testing.T) {
 	if err := Mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %s", err)
 	}
+
+	assert.Equal(t, clientID, 1)
 }
 
 func TestSignIn_ShouldSignInExistingClient(t *testing.T) {

--- a/pkg/service/responses.go
+++ b/pkg/service/responses.go
@@ -7,7 +7,9 @@
  */
 package service
 
-import "github.com/msgurgel/marathon/pkg/model"
+import (
+	"github.com/msgurgel/marathon/pkg/model"
+)
 
 type GetUserStepsResponse200 struct {
 	ID int `json:"id,omitempty"`
@@ -28,8 +30,10 @@ type GetUserDistanceResponse200 struct {
 }
 
 type ClientSignUpResponse struct {
-	Success bool   `json:"success"`
-	Error   string `json:"error,omitempty"`
+	Success    bool   `json:"success"`
+	ClientID   int    `json:"clientID"`
+	ClientName string `json:"clientName"`
+	Error      string `json:"error,omitempty"`
 }
 
 type ClientSignInResponse struct {

--- a/pkg/service/routers.go
+++ b/pkg/service/routers.go
@@ -41,7 +41,7 @@ func NewRouter(db *sql.DB, logger *logrus.Logger, config *environment.MarathonCo
 			handler = jwtMiddleware(db, logger, handler)
 		}
 		if route.MarathonWebsiteOnly {
-			handler = checkOrigin(logger, handler, config.MarathonWebsiteURL)
+			handler = checkMarathonURL(logger, handler, config.MarathonWebsiteURL)
 		}
 		handler = Logger(logger, handler, route.Name)
 


### PR DESCRIPTION
A quick edit to the SignUp api method, now when a client successfully signs up, the response will return the client name and id, along with the success message.

Before it only returned the success message.