### PR TITLE
Delete setup-db-env-vars.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@
 .DS_Store
 runtime.log
 log/
-setup-db-env-vars.sh
 vendor/

--- a/integration/integration-test.sh
+++ b/integration/integration-test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e # Any subsequent(*) commands which fail will cause the shell script to exit immediately
 
 # ======= BEFORE RUNNING THIS SCRIPT =======
 # 1. Make sure to run 'bundle install' on the both ruby app directories (integration/sandwich & integration/sandwich/server)
@@ -7,14 +8,14 @@
 #   ./integration/integration-test.sh
 
 # Get database environment values
-source ./integration/setup-db-env-vars.sh
+source ./.env
 
 # Create log directory
 mkdir -p log
 
 # Run setup database script
-psql -a -d $PGDATABASE -f integration/sql/clear-db.sql > log/db_script.log
-psql -a -d $PGDATABASE -f integration/sql/setup-db.sql > log/db_script.log
+psql -a $DB_CONNECTION_STRING -f integration/sql/clear-db.sql > log/db_script.log
+psql -a $DB_CONNECTION_STRING -f integration/sql/setup-db.sql > log/db_script.log
 
 # Build and run Marathon
 go build "$GOPATH"/src/github.com/msgurgel/marathon/cmd/marathon
@@ -43,4 +44,4 @@ rm ./marathon
 rm ./token.txt
 
 # Clear database
-psql -a -d $PGDATABASE -f integration/sql/clear-db.sql > log/db_script.log
+psql -a $DB_CONNECTION_STRING -f integration/sql/clear-db.sql > log/db_script.log

--- a/integration/setup-db-env-vars.sh.example
+++ b/integration/setup-db-env-vars.sh.example
@@ -1,6 +1,0 @@
-# PostgreSQL Vars
-PGHOST=localhost
-PGPORT=5432
-PGUSER=
-PGPASSWORD=
-PGDATABASE=marathon


### PR DESCRIPTION
Closes #65 

Removes the need for `setup-db-env-vars.sh`. Now, we read the environment variables necessary for the integration test directly from the `.env` file.

### IMPORTANT
After this PR, the `.env` file can no longer contain spaces around the equal signs.

#### Before
```shell
PORT          = 8080
READ_TIMEOUT  = 15
WRITE_TIMEOUT = 15
IDLE_TIMEOUT  = 60
```
#### Now
```shell
PORT=8080
READ_TIMEOUT=15
WRITE_TIMEOUT=15
IDLE_TIMEOUT=60
```