### PR TITLE
Check if PORT is set

### DIFF
--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -83,8 +83,13 @@ func ReadEnvFile(env string) (*MarathonConfig, error) {
 		return nil, errors.New("failed to convert IDLE_TIMEOUT to int")
 	}
 
+	port := os.Getenv("PORT")
+	if port == "" {
+		return nil, errors.New("environment variable PORT is not set")
+	}
+
 	srv := serverConfig{
-		Port:         os.Getenv("PORT"),
+		Port:         port,
 		ReadTimeOut:  time.Second * time.Duration(readTime),
 		WriteTimeOut: time.Second * time.Duration(writeTime),
 		IdleTimeout:  time.Second * time.Duration(idleTime),


### PR DESCRIPTION
Closes #68 

The last environment variable that was not being checked, `PORT`, is now being checked during the reading of env vars. The checks for other variables were added in #80 