### PR TITLE
Add endpoints to get largest calories, steps or distance

### DIFF
--- a/integration/sandwich/sandwich_test.rb
+++ b/integration/sandwich/sandwich_test.rb
@@ -86,9 +86,55 @@ class SandwichTest < Minitest::Test
 
                 assert_equal 'google', parsed["calories"][1]["platform"]
                 assert_equal 1635, parsed["calories"][1]["value"]
-
-
     end
+
+    def test_get_max_calories
+                response = HTTParty.get('http://localhost:8080/user/3/calories/max?date=2020-02-13', {
+                    headers: {
+                        "User-Agent" => "Sandwich",
+                        "Authorization" => "Bearer #{@jwt}",
+                        }
+                    })
+
+                    parsed = JSON.parse(response.body)
+                    assert_equal 3, parsed["id"]
+
+                    # There should only be the google platform returned, because it has more calories than Fitbit
+                    assert_equal 'google', parsed["calories"][0]["platform"]
+                    assert_equal 1635, parsed["calories"][0]["value"]
+    end
+
+    def test_get_max_steps
+                    response = HTTParty.get('http://localhost:8080/user/3/steps/max?date=2020-02-13', {
+                        headers: {
+                            "User-Agent" => "Sandwich",
+                            "Authorization" => "Bearer #{@jwt}",
+                            }
+                        })
+
+                        parsed = JSON.parse(response.body)
+                        assert_equal 3, parsed["id"]
+
+                        # The Fitbit platform has more steps than Google, so it should return the Fitbit Amount
+                        assert_equal 'fitbit', parsed["steps"][0]["platform"]
+                        assert_equal 2020, parsed["steps"][0]["value"]
+    end
+
+    def test_get_max_distance
+                        response = HTTParty.get('http://localhost:8080/user/3/distance/max?date=2020-02-13', {
+                            headers: {
+                                "User-Agent" => "Sandwich",
+                                "Authorization" => "Bearer #{@jwt}",
+                                }
+                            })
+
+                            parsed = JSON.parse(response.body)
+                            assert_equal 3, parsed["id"]
+
+                            # Google has more distance than fitbit
+                            assert_equal 'google', parsed["distance"][0]["platform"]
+                            assert_equal 3.456, parsed["distance"][0]["value"]
+        end
 
     def test_client_signup_name_already_taken
         response = HTTParty.post(

--- a/pkg/service/api.go
+++ b/pkg/service/api.go
@@ -103,6 +103,14 @@ func (api *Api) GetToken(w http.ResponseWriter, r *http.Request) {
 }
 
 func (api *Api) GetUserCalories(w http.ResponseWriter, r *http.Request) {
+	api.getCalories(w, r, false)
+}
+
+func (api *Api) GetLargestUserCalories(w http.ResponseWriter, r *http.Request) {
+	api.getCalories(w, r, true)
+}
+
+func (api *Api) getCalories(w http.ResponseWriter, r *http.Request, onlyReturnLargestValue bool) {
 	userID, date, err := api.getRequestParams(r, logrus.Fields{"func": "GetUserCalories"})
 	if err != nil {
 		api.respondWithError(w, http.StatusBadRequest, err.Error())
@@ -112,7 +120,7 @@ func (api *Api) GetUserCalories(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	caloriesValues, err := model.GetUserCalories(api.db, api.log, userID, date)
+	caloriesValues, err := model.GetUserCalories(api.db, api.log, userID, date, onlyReturnLargestValue)
 	if err != nil {
 		// TODO: Change this to a more fitting HTTP code
 		api.respondWithError(w, http.StatusInternalServerError, err.Error())
@@ -127,6 +135,14 @@ func (api *Api) GetUserCalories(w http.ResponseWriter, r *http.Request) {
 }
 
 func (api *Api) GetUserDistance(w http.ResponseWriter, r *http.Request) {
+	api.getDistance(w, r, false)
+}
+
+func (api *Api) GetLargestDistance(w http.ResponseWriter, r *http.Request) {
+	api.getDistance(w, r, true)
+}
+
+func (api *Api) getDistance(w http.ResponseWriter, r *http.Request, onlyReturnLargestValue bool) {
 	userID, date, err := api.getRequestParams(r, logrus.Fields{"func": "GetUserDistance"})
 	if err != nil {
 		api.respondWithError(w, http.StatusBadRequest, err.Error())
@@ -136,7 +152,7 @@ func (api *Api) GetUserDistance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	distanceValues, err := model.GetUserDistance(api.db, api.log, userID, date)
+	distanceValues, err := model.GetUserDistance(api.db, api.log, userID, date, onlyReturnLargestValue)
 	if err != nil {
 		// TODO: Change this to a more fitting HTTP code
 		api.respondWithError(w, http.StatusInternalServerError, err.Error())
@@ -151,6 +167,14 @@ func (api *Api) GetUserDistance(w http.ResponseWriter, r *http.Request) {
 }
 
 func (api *Api) GetUserSteps(w http.ResponseWriter, r *http.Request) {
+	api.getSteps(w, r, false)
+}
+
+func (api *Api) GetLargestSteps(w http.ResponseWriter, r *http.Request) {
+	api.getSteps(w, r, true)
+}
+
+func (api *Api) getSteps(w http.ResponseWriter, r *http.Request, onlyReturnLargestValue bool) {
 	userID, date, err := api.getRequestParams(r, logrus.Fields{"func:": "GetUserSteps"})
 	if err != nil {
 		api.respondWithError(w, http.StatusBadRequest, err.Error())
@@ -161,7 +185,7 @@ func (api *Api) GetUserSteps(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	stepsValues, err := model.GetUserSteps(api.db, api.log, userID, date)
+	stepsValues, err := model.GetUserSteps(api.db, api.log, userID, date, onlyReturnLargestValue)
 	if err != nil {
 		// TODO: Change this to a more fitting HTTP code
 		api.respondWithError(w, http.StatusInternalServerError, err.Error())

--- a/pkg/service/routers.go
+++ b/pkg/service/routers.go
@@ -97,12 +97,29 @@ func prepareRoutes(db *sql.DB, logger *logrus.Logger, authTypes auth.Types) Rout
 		},
 
 		Route{
+			"GetLargestUserCalories",
+			"GET",
+			"/user/{userID}/calories/largest",
+			true,
+			false,
+			api.GetLargestUserCalories,
+		},
+
+		Route{
 			"GetUserSteps",
 			"GET",
 			"/user/{userID}/steps",
 			true,
 			false,
 			api.GetUserSteps,
+		},
+		Route{
+			"GetLargestUserSteps",
+			"GET",
+			"/user/{userID}/steps/largest",
+			true,
+			false,
+			api.GetLargestSteps,
 		},
 
 		Route{
@@ -112,6 +129,15 @@ func prepareRoutes(db *sql.DB, logger *logrus.Logger, authTypes auth.Types) Rout
 			true,
 			false,
 			api.GetUserDistance,
+		},
+
+		Route{
+			"GetLargestUserDistance",
+			"GET",
+			"/user/{userID}/distance/largest",
+			true,
+			false,
+			api.GetLargestDistance,
 		},
 
 		Route{


### PR DESCRIPTION
Add the endpoints to only return the result from the platform with the largest value.

New endpoints are: 
"/user/{userID}/calories/largest"
"/user/{userID}/steps/largest"
"/user/{userID}/distance/largest"