### PR TITLE
Rename userID to clientID in signIn response

### DIFF
--- a/pkg/service/responses.go
+++ b/pkg/service/responses.go
@@ -35,7 +35,7 @@ type ClientSignUpResponse struct {
 
 type ClientSignInResponse struct {
 	Success  bool   `json:"success"`
-	ClientID int    `json:"userID,omitempty"`
+	ClientID int    `json:"clientID,omitempty"`
 	Error    string `json:"error,omitempty"`
 }
 


### PR DESCRIPTION
Fix the improper naming in the SignIn response