### PR TITLE
Fix error message

### DIFF
--- a/pkg/service/api.go
+++ b/pkg/service/api.go
@@ -623,7 +623,7 @@ func (api *Api) UpdateClientCallback(w http.ResponseWriter, r *http.Request) {
 	if newCallback == "" {
 		response := CallbackUpdateResponse{
 			Success: false,
-			Error:   "Expected parameter 'name' in request",
+			Error:   "Expected parameter 'callback' in request",
 		}
 		api.respondWithJSON(w, http.StatusBadRequest, response)
 


### PR DESCRIPTION
If api does not have the callback, return a proper error message with the correct name of the missing variable