### PR TITLE
Add get client callback

### DIFF
--- a/integration/sandwich/sandwich_test.rb
+++ b/integration/sandwich/sandwich_test.rb
@@ -226,12 +226,13 @@ class SandwichTest < Minitest::Test
 
     def test_client_signin_wrong_password
         response = HTTParty.post('http://localhost:8080/signin', {
+            :multipart => true,
             :body => {
                 :name => 'Sandwich',
                 :password => 'Bad_Password'
             },
             :headers => {
-                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Content-Type' => 'multipart/form-data',
                 'Origin' => 'https://marathon-18119.firebaseapp.com'
             }
         })
@@ -243,11 +244,12 @@ class SandwichTest < Minitest::Test
 
     def test_client_update_callback_incorrect_client
             response = HTTParty.post('http://localhost:8080/client/34/callback', {
+                :multipart => true,
                 :body => {
                     :callback => 'Sandwich'
                 },
                 :headers => {
-                    'Content-Type' => 'application/x-www-form-urlencoded',
+                    'Content-Type' => 'multipart/form-data',
                     'Origin' => 'https://marathon-18119.firebaseapp.com'
                 }
             })
@@ -259,11 +261,12 @@ class SandwichTest < Minitest::Test
 
     def test_client_update_callback_non_integer_clientID
                 response = HTTParty.post('http://localhost:8080/client/notaninteger/callback', {
+                    :multipart => true,
                     :body => {
                         :callback => 'Sandwich'
                     },
                     :headers => {
-                        'Content-Type' => 'application/x-www-form-urlencoded',
+                        'Content-Type' => 'multipart/form-data',
                         'Origin' => 'https://marathon-18119.firebaseapp.com'
                     }
                 })
@@ -275,11 +278,12 @@ class SandwichTest < Minitest::Test
 
     def test_client_update_callback_correct_call
                     response = HTTParty.post('http://localhost:8080/client/1/callback', {
+                        :multipart => true,
                         :body => {
                             :callback => 'Sandwich_callback'
                         },
                         :headers => {
-                            'Content-Type' => 'application/x-www-form-urlencoded',
+                            'Content-Type' => 'multipart/form-data',
                             'Origin' => 'https://marathon-18119.firebaseapp.com'
                         }
                     })

--- a/pkg/dal/dal.go
+++ b/pkg/dal/dal.go
@@ -382,6 +382,25 @@ func UpdateCredentials(db *sql.DB, userID int, credentialsString string) error {
 	return nil
 }
 
+func GetClientCallback(db *sql.DB, clientID int) (string, error) {
+	searchQuery := fmt.Sprintf("SELECT callback FROM client WHERE id = %d", clientID)
+
+	var callbackResult string
+	err := db.QueryRow(searchQuery).Scan(&callbackResult) // TODO: Use QueryRowContext instead
+	if err != nil {
+		if err == sql.ErrNoRows {
+			// There were no rows, but otherwise no error occurred.
+			// Received a client ID that doesn't exist
+			return "", nil
+		} else {
+			return "", err
+		}
+	}
+
+	// We found a result, return it
+	return callbackResult, nil
+}
+
 func UpdateCredentialsUsingOAuth2Tokens(db *sql.DB, userID int, tokens *oauth2.Token) error {
 	connStr, err := helpers.FormatConnectionString([]string{
 		"oauth2",

--- a/pkg/dal/dal_test.go
+++ b/pkg/dal/dal_test.go
@@ -550,3 +550,46 @@ func TestInsertNewUser_ShouldInsertUser(t *testing.T) {
 
 	assert.Equal(t, 1, userID)
 }
+
+func TestGetClientCallback_ShouldGetClientCallback(t *testing.T) {
+	clientID := 1
+	callback := "testCallback"
+
+	Mock.ExpectQuery(
+		fmt.Sprintf("SELECT callback FROM client WHERE id = %d", clientID)).
+		WillReturnRows(sqlmock.NewRows([]string{"callback"}).AddRow(callback))
+
+	// Call the function we are testing
+	callbackResult, err := GetClientCallback(DB, clientID)
+	if err != nil {
+		t.Errorf("error was not expected when getting a client callback: %s", err)
+	}
+
+	// We make sure that all expectations were met
+	if err := Mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+
+	assert.Equal(t, callback, callbackResult)
+}
+
+func TestGetClientCallback_NoClientShouldReturnBlank(t *testing.T) {
+	clientID := 1
+
+	Mock.ExpectQuery(
+		fmt.Sprintf("SELECT callback FROM client WHERE id = %d", clientID)).
+		WillReturnRows(sqlmock.NewRows([]string{"callback"}))
+
+	// Call the function we are testing
+	callbackResult, err := GetClientCallback(DB, clientID)
+	if err != nil {
+		t.Errorf("error was not expected when getting a client callback: %s", err)
+	}
+
+	// We make sure that all expectations were met
+	if err := Mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+	}
+
+	assert.Equal(t, "", callbackResult)
+}

--- a/pkg/service/responses.go
+++ b/pkg/service/responses.go
@@ -39,6 +39,12 @@ type ClientSignInResponse struct {
 	Error    string `json:"error,omitempty"`
 }
 
+type GetCallbackResponse struct {
+	Success  bool   `json:"success"`
+	Error    string `json:"error,omitempty"`
+	Callback string `json:"callback,omitempty"`
+}
+
 type CallbackUpdateResponse struct {
 	Success         bool   `json:"success"`
 	Error           string `json:"error,omitempty"`

--- a/pkg/service/routers.go
+++ b/pkg/service/routers.go
@@ -168,6 +168,15 @@ func prepareRoutes(db *sql.DB, logger *logrus.Logger, authTypes auth.Types) Rout
 		},
 
 		Route{
+			"Callback",
+			"GET",
+			"/client/{clientID}/callback",
+			false,
+			true,
+			api.GetClientCallback,
+		},
+
+		Route{
 			"SignUp",
 			"POST",
 			"/signup",


### PR DESCRIPTION
Allow a currently logged in client to get their client callback.
This is a Marathon-specific call, so no authorization token in expected.